### PR TITLE
add initial template for storage account and app insights

### DIFF
--- a/infra/deploytostorageaccount.bicep
+++ b/infra/deploytostorageaccount.bicep
@@ -1,0 +1,97 @@
+// This template deploys an Azure Storage account, and then configures it to support static website hosting.
+// Enabling static website hosting isn't possible directly in Bicep or an ARM template,
+// so this sample uses a deployment script to enable the feature.
+
+param location string = resourceGroup().location
+param accountName string
+param appInsightsName string
+
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_ZRS'
+  'Premium_LRS'
+])
+param skuName string
+
+param customDomain object = {}
+
+param deploymentScriptTimestamp string = utcNow()
+param indexDocument string = 'index.html'
+param errorDocument404Path string = 'error.html'
+
+var storageAccountContributorRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab') // This is the Storage Account Contributor role, which is the minimum role permission we can give. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#:~:text=17d1049b-9a84-46fb-8f53-869881c3d3ab
+
+resource appinsights 'Microsoft.Insights/components@2018-05-01-preview' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
+  name: accountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: skuName
+  }
+  properties: {
+    customDomain: customDomain
+  }
+}
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: 'DeploymentScript'
+  location: location
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  scope: storageAccount
+  name: guid(resourceGroup().id, storageAccountContributorRoleDefinitionId)
+  properties: {
+    roleDefinitionId: storageAccountContributorRoleDefinitionId
+    principalType: 'ServicePrincipal'
+    principalId: managedIdentity.properties.principalId
+  }
+}
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'deploymentScript'
+  location: location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentity.id}': {}
+    }
+  }
+  dependsOn: [
+    roleAssignment
+    storageAccount
+  ]
+  properties: {
+    azPowerShellVersion: '3.0'
+    scriptContent: '''
+param(
+    [string] $ResourceGroupName,
+    [string] $StorageAccountName,
+    [string] $IndexDocument,
+    [string] $ErrorDocument404Path)
+
+$ErrorActionPreference = 'Stop'
+$storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $StorageAccountName
+
+$ctx = $storageAccount.Context
+Enable-AzStorageStaticWebsite -Context $ctx -IndexDocument $IndexDocument -ErrorDocument404Path $ErrorDocument404Path
+'''
+    forceUpdateTag: deploymentScriptTimestamp
+    retentionInterval: 'PT4H'
+    arguments: '-ResourceGroupName ${resourceGroup().name} -StorageAccountName ${accountName} -IndexDocument ${indexDocument} -ErrorDocument404Path ${errorDocument404Path}'
+  }
+}
+
+output scriptLogs string = reference('${deploymentScript.id}/logs/default', deploymentScript.apiVersion, 'Full').properties.log
+output staticWebsiteHostName string = replace(replace(storageAccount.properties.primaryEndpoints.web, 'https://', ''), '/', '')


### PR DESCRIPTION
Added template to deploy storage account with static site support as well as App Insights instance.
deploy with:
```bash
az deployment group create --name ftaaaswebfe --template-file infra/deploytostorageaccount.bicep --parameters accountName=<ftaaastest> appInsightsName=<ftaaastest> skuName=Standard_LRS -g <ftaaastest>