### PR TITLE
Included Statuses filter and an option to view excluded tags

### DIFF
--- a/src/controls/Ft3asApp.tsx
+++ b/src/controls/Ft3asApp.tsx
@@ -16,6 +16,7 @@ import { IGraphQueryResult } from "../model/IGraphQueryResult";
 import { getAppInsights } from "../service/TelemetryService";
 import TelemetryProvider from '../service/telemetry-provider';
 import CsvGeneratorInstance from '../service/CsvGenerator';
+import { IStatus } from "../model/IStatus";
 
 const stackTokens: IStackTokens = { childrenGap: 15 };
 const stackStyles: Partial<IStackStyles> = {
@@ -38,6 +39,7 @@ export default function Ft3asApp() {
     const [percentComplete, setPercentComplete] = useState(0);
     const [visibleCategories, setVisibleCategories] = useState<ICategory[]>();
     const [visibleSeverities, setVisibleSeverities] = useState<ISeverity[]>();
+    const [visibleStatuses, setVisibleStatuses] = useState<IStatus[]>();
     const [filterText, setFilterText] = useState('');
 
     let appInsights = null;
@@ -79,6 +81,7 @@ export default function Ft3asApp() {
         });
         setVisibleCategories(doc.categories);
         setVisibleSeverities(doc.severities);
+        setVisibleStatuses(doc.status);
     }
     // useEffect(()=>{setChecklistDoc(checklistDoc)}, [checklistDoc]);
 
@@ -277,6 +280,7 @@ export default function Ft3asApp() {
                         checklistDoc={checklistDoc}
                         categoriesChanged={setVisibleCategories}
                         severitiesChanged={setVisibleSeverities}
+                        statusesChanged={setVisibleStatuses}
                         filterTextChanged={setFilterText}
                         onClose={() => setShowFilters(false)}></Ft3asFilters>) : (<></>)}
 
@@ -286,6 +290,7 @@ export default function Ft3asApp() {
                             questionAnswered={definePercentComplete}
                             visibleCategories={visibleCategories}
                             visibleSeverities={visibleSeverities}
+                            visibleStatuses={visibleStatuses}
                             filterText={filterText}
                         >
                         </Ft3asChecklist>

--- a/src/controls/Ft3asChecklist.tsx
+++ b/src/controls/Ft3asChecklist.tsx
@@ -8,6 +8,7 @@ import { ICategory, IChecklistDocument } from '../model/IChecklistDocument';
 import { Label, Separator, Stack } from '@fluentui/react';
 import Ft3asItemEdition from './Ft3asItemEdition';
 import { ISeverity } from '../model/ISeverity';
+import { IStatus } from '../model/IStatus';
 
 const classNames = mergeStyleSets({
   controlWrapper: {
@@ -44,6 +45,7 @@ interface Ft3asChecklistProps {
   questionAnswered?: (percentComplete: number) => void;
   visibleCategories?: ICategory[];
   visibleSeverities?: ISeverity[];
+  visibleStatuses?: IStatus[];
   filterText?: string;
 }
 
@@ -153,7 +155,7 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
       },
     });
 
-    const items = this.filterSourceItems(this.props.checklistDoc?.items ?? [], this.props.visibleCategories, this.props.visibleSeverities, this.props.filterText);
+    const items = this.filterSourceItems(this.props.checklistDoc?.items ?? [], this.props.visibleCategories, this.props.visibleSeverities, this.props.visibleStatuses, this.props.filterText);
     this.state = {
       allItems: items,
       items: items,
@@ -166,7 +168,7 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
   }
 
   public componentWillReceiveProps(props: Ft3asChecklistProps) {
-    const items = this.filterSourceItems(props.checklistDoc?.items ?? [], props.visibleCategories, props.visibleSeverities, props.filterText);
+    const items = this.filterSourceItems(props.checklistDoc?.items ?? [], props.visibleCategories, props.visibleSeverities, props.visibleStatuses, props.filterText);
 
     this.setState({
       items: items
@@ -179,17 +181,18 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
     }
   }
 
-  private filterSourceItems(items: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], filterText?: string): ICheckItemAnswered[] {
+  private filterSourceItems(items: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], visibleStatuses?: IStatus[], filterText?: string): ICheckItemAnswered[] {
 
     if (!visibleSeverities) {
       console.log('no severities??');
     }
 
     const _filterText= filterText?.toLowerCase();
-
+    
     return items.filter(item =>
       (visibleCategories === undefined || visibleCategories.findIndex(c => c.name === item.category) !== -1)
       && (visibleSeverities === undefined || visibleSeverities.findIndex(s => s.name.toLowerCase() === item.severity.toString().toLowerCase()) !== -1)
+      && (visibleStatuses === undefined || visibleStatuses.findIndex(s => item.status && s.name.toLowerCase() === item.status.name.toLowerCase()) !== -1)
       && (_filterText === undefined || _filterText.trim() == '' || item.category.toLowerCase().indexOf(_filterText) !== -1 || item.subcategory.toLowerCase().indexOf(_filterText) !== -1 || item.text.toLowerCase().indexOf(_filterText) !== -1 || item.severity.toString().toLowerCase().indexOf(_filterText) !== -1));
   }
   private onItemChanged(item: ICheckItemAnswered) {

--- a/src/controls/Ft3asFilters.tsx
+++ b/src/controls/Ft3asFilters.tsx
@@ -1,8 +1,9 @@
-import { IInputProps, ITag, Panel, TagPicker } from '@fluentui/react';
+import { IInputProps, ITag, Panel, TagPicker, IBasePicker } from '@fluentui/react';
 import * as React from 'react';
 import { ICategory, IChecklistDocument } from "../model/IChecklistDocument";
 import { ICheckItemAnswered } from "../model/ICheckItem";
 import { ISeverity } from '../model/ISeverity';
+import { IStatus } from '../model/IStatus';
 import { TextField } from '@fluentui/react/lib/TextField';
 
 
@@ -26,12 +27,13 @@ interface Ft3asFiltersProps {
     isOpen: boolean;
     categoriesChanged?: (selectedCategories: ICategory[]) => void
     severitiesChanged?: (selectedSeverities: ISeverity[]) => void
+    statusesChanged?: (selectedStatuses: IStatus[]) => void
     filterTextChanged?: (filterText: string) => void
     onClose: () => void;
 }
 export default function Ft3asFilters(props: Ft3asFiltersProps) {
 
-    const { categories, severities } = props.checklistDoc;
+    const { categories, severities, status } = props.checklistDoc;
     const { isOpen } = props;
     const availableTags = categories.map<ITag>(c => {
         return { key: c.name, name: c.name }
@@ -39,6 +41,14 @@ export default function Ft3asFilters(props: Ft3asFiltersProps) {
     const availableSeverities = severities.map<ITag>(s => {
         return { key: s.name, name: s.name }
     });
+    const availableStatuses = status.map<ITag>(s => {
+        return { key: s.name, name: s.name }
+    });
+
+    const [excludedTags, setExcludedTags] = React.useState<ITag[]>([]);
+    const [excludedSeverities, setExcludedSeverities] = React.useState<ITag[]>([]);
+    const [excludedStatuses, setExcludedStatuses] = React.useState<ITag[]>([]);
+    
 
     const filterSuggestedCategoryTags = (filterText: string, tagList?: ITag[]): ITag[] => {
         return filterText
@@ -47,9 +57,43 @@ export default function Ft3asFilters(props: Ft3asFiltersProps) {
             : [];
     };
 
+    const filterExcludedCategoryTags = (filterText: string, tagList?: ITag[]): ITag[] => {
+        console.log(filterText)
+        console.log(tagList)
+        return filterText
+            ? excludedTags.filter(
+                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
+            : [];
+    };
+
     const filterSuggestedSeveritiesTags = (filterText: string, tagList?: ITag[]): ITag[] => {
         return filterText
             ? availableSeverities.filter(
+                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
+            : [];
+    };
+
+    const filterExcludedSeverityTags = (filterText: string, tagList?: ITag[]): ITag[] => {
+        console.log(filterText)
+        console.log(tagList)
+        return filterText
+            ? excludedSeverities.filter(
+                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
+            : [];
+    };
+
+    const filterSuggestedStatusesTags = (filterText: string, tagList?: ITag[]): ITag[] => {
+        return filterText
+            ? availableStatuses.filter(
+                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
+            : [];
+    };
+
+    const filterExcludedStatusesTags = (filterText: string, tagList?: ITag[]): ITag[] => {
+        console.log(filterText)
+        console.log(tagList)
+        return filterText
+            ? excludedStatuses.filter(
                 tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
             : [];
     };
@@ -62,6 +106,12 @@ export default function Ft3asFilters(props: Ft3asFiltersProps) {
                 }
             }) ?? []);
         }
+
+        let _excludedTags : ITag[] = [];
+        setExcludedTags([]);
+        availableTags.forEach( (tag: ITag) => { if(!listContainsTagList(tag, items)) { _excludedTags.push(tag)} });
+        setExcludedTags(_excludedTags);
+
     };
 
     const onSeveritiesPickerChanged = (items?: ITag[] | undefined) => {
@@ -73,6 +123,27 @@ export default function Ft3asFilters(props: Ft3asFiltersProps) {
                 }
             }) ?? []);
         }
+
+        let _excludedSeverities : ITag[] = [];
+        setExcludedSeverities([]);
+        availableSeverities.forEach( (tag: ITag) => { if(!listContainsTagList(tag, items)) { _excludedSeverities.push(tag)} });
+        setExcludedSeverities(_excludedSeverities);
+    };
+
+    const onStatusesPickerChanged = (items?: ITag[] | undefined) => {
+        if (props.statusesChanged) {
+            props.statusesChanged(items?.map<IStatus>(item => {
+                return {
+                    name: item.name,
+                    description: item.name
+                }
+            }) ?? []);
+        }
+
+        let _excludedStatuses : ITag[] = [];
+        setExcludedStatuses([]);
+        availableStatuses.forEach( (tag: ITag) => { if(!listContainsTagList(tag, items)) { _excludedStatuses.push(tag)} });
+        setExcludedStatuses(_excludedStatuses);
     };
   
     const _onChangeText = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text?: string): void => {
@@ -102,16 +173,28 @@ export default function Ft3asFilters(props: Ft3asFiltersProps) {
                     suggestionsHeaderText: 'Suggested categories',
                     noResultsFoundText: 'No categories found'
                 }}
-
                 defaultSelectedItems={availableTags}
                 inputProps={{
                     ...inputProps,
                     id: 'picker1',
                 }}
-
                 onChange={onCategoriesPickerChanged}
 
             />
+
+            <label htmlFor='picker3'>Excluded categories</label>
+            <TagPicker
+                removeButtonAriaLabel="Remove"
+                selectionAriaLabel="Excluded categories"
+                onResolveSuggestions={filterExcludedCategoryTags}
+                selectedItems={excludedTags}
+                getTextFromItem={getTextFromItem}
+                inputProps={{
+                    ...inputProps,
+                    id: 'picker3',
+                }}
+            />
+
             <label htmlFor='picker2'>Included severities</label>
             <TagPicker
                 removeButtonAriaLabel="Remove"
@@ -134,6 +217,55 @@ export default function Ft3asFilters(props: Ft3asFiltersProps) {
                 }}
                 onChange={onSeveritiesPickerChanged}
             />
+
+            <label htmlFor='picker4'>Excluded severities</label>
+            <TagPicker
+                removeButtonAriaLabel="Remove"
+                selectionAriaLabel="Excluded severities"
+                onResolveSuggestions={filterExcludedSeverityTags}
+                selectedItems={excludedSeverities}
+                getTextFromItem={getTextFromItem}
+                inputProps={{
+                    ...inputProps,
+                    id: 'picker4',
+                }}
+            />
+
+            <label htmlFor='picker5'>Included statuses</label>
+            <TagPicker
+                removeButtonAriaLabel="Remove"
+                selectionAriaLabel="Included statuses"
+                
+                onItemSelected={(selectedItem?: ITag) => {
+                    console.debug('selected item ' + selectedItem?.name);
+                    return selectedItem ?? null;
+                }}
+                onResolveSuggestions={filterSuggestedStatusesTags}
+                getTextFromItem={getTextFromItem}
+                pickerSuggestionsProps={{
+                    suggestionsHeaderText: 'Suggested statuses',
+                    noResultsFoundText: 'No statuses found'
+                }}
+                defaultSelectedItems={availableStatuses}
+                inputProps={{
+                    ...inputProps,
+                    id: 'picker5',
+                }}
+                onChange={onStatusesPickerChanged}
+            />
+
+            <label htmlFor='picker6'>Excluded statuses</label>
+            <TagPicker
+                removeButtonAriaLabel="Remove"
+                selectionAriaLabel="Excluded statuses"
+                onResolveSuggestions={filterExcludedStatusesTags}
+                selectedItems={excludedStatuses}
+                getTextFromItem={getTextFromItem}
+                inputProps={{
+                    ...inputProps,
+                    id: 'picker6',
+                }}
+            />            
         </Panel>
     );
 }


### PR DESCRIPTION
Not sure if it is expected to include a status filter.
Added a picker to sync the excluded tags. Unable to tap into any event on the excluded picker to restore it to the included picker