### PR TITLE
Feature/ft3as poc leftovers

### DIFF
--- a/src/controls/Ft3asApp.tsx
+++ b/src/controls/Ft3asApp.tsx
@@ -32,7 +32,7 @@ export default function Ft3asApp() {
     const [isModified, setIsModified] = useState(false);
     const [checklistDoc, setChecklistDoc] = useState<IChecklistDocument>();
     const [showSelectTemplate, setShowSelectTemplate] = useState(false);
-    const [showFilters, setShowFilters] = useState(true);
+    const [showFilters, setShowFilters] = useState(false);
     const [percentComplete, setPercentComplete] = useState(0);
     const [visibleCategories, setVisibleCategories] = useState<ICategory[]>();
     const [visibleSeverities, setVisibleSeverities] = useState<ISeverity[]>();
@@ -259,14 +259,13 @@ export default function Ft3asApp() {
         }
     }
 
-
     const definePercentComplete = (percentComplete: number) => {
         setPercentComplete(percentComplete);
         setIsModified(true);
     }
 
     return (
-        <Stack verticalFill styles={stackStyles} tokens={stackTokens}>
+        <Stack styles={stackStyles} tokens={stackTokens}>
             <Ft3asToolbar
                 isModified={isModified}
                 onFilter={e => { setShowFilters(true) }}

--- a/src/controls/Ft3asChecklist.tsx
+++ b/src/controls/Ft3asChecklist.tsx
@@ -7,9 +7,7 @@ import { ICheckItemAnswered } from '../model/ICheckItem';
 import { ICategory, IChecklistDocument } from '../model/IChecklistDocument';
 import { Label, Separator, Stack, IDropdownOption, IStackStyles } from '@fluentui/react';
 import { ISeverity } from '../model/ISeverity';
-
 import { IStatus } from '../model/IStatus';
-
 import Ft3asItemDetail from './Ft3asItemDetail';
 
 const classNames = mergeStyleSets({
@@ -46,7 +44,6 @@ export interface Ft3asChecklistState {
   announcedMessage?: string;
   currentItem?: ICheckItemAnswered;
   groups: IGroup[];
-  //groupingField: IDropdownOption;
 }
 
 interface Ft3asChecklistProps {
@@ -62,24 +59,10 @@ interface Ft3asChecklistProps {
 export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asChecklistState> {
   private _selection: Selection;
 
-  // private _allItems: ICheckItemAnswered[];
   constructor(props: Ft3asChecklistProps) {
     super(props);
 
     const columns: IColumn[] = [
-      {
-        key: 'category',
-        name: 'Category',
-        ariaLabel: 'Category',
-        fieldName: 'category',
-        minWidth: 110,
-        maxWidth: 250,
-        isRowHeader: true,
-        isResizable: true,
-        isSorted: true,
-        data: 'string',
-        onColumnClick: this._onColumnClick,
-      },
       {
         key: 'subcategory',
         name: 'Subcategory',
@@ -136,21 +119,8 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
         isCollapsible: true,
         data: 'string',
         onColumnClick: this._onColumnClick,
-      },
-      {
-        key: 'link',
-        name: 'Link',
-        fieldName: 'link',
-        minWidth: 210,
-        maxWidth: 360,
-        isResizable: true,
-        isCollapsible: true,
-        data: 'url',
-        onColumnClick: this._onColumnClick,
-      },
-
+      }
     ];
-
 
     this._selection = new Selection({
       onSelectionChanged: () => {
@@ -173,9 +143,6 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
       announcedMessage: "announce message",
       groups: result.groups,
     };
-
-    // this.setState(this.state);
-
   }
 
   private setGroups(initialItems: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], visibleStatuses?: IStatus[],  groupingField?: string, columns?: IColumn[])
@@ -238,11 +205,6 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
   }
 
   private filterSourceItems(items: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], visibleStatuses?: IStatus[], filterText?: string): ICheckItemAnswered[] {
-
-    if (!visibleSeverities) {
-      console.log('no severities??');
-    }
-
     const _filterText= filterText?.toLowerCase();
     
     return items.filter(item =>
@@ -338,12 +300,10 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
                 isHeaderVisible={true}
                 selection={this._selection}
                 selectionPreservedOnEmptyClick={true}
-                onItemInvoked={this._onItemInvoked}
                 enterModalSelectionOnTouch={true}
                 ariaLabelForSelectionColumn="Toggle selection"
                 ariaLabelForSelectAllCheckbox="Toggle selection for all items"
                 checkButtonAriaLabel="select row"
-                onActiveItemChanged={(item) => console.log('active item changed ' + item)}
               />
             </MarqueeSelection>
 
@@ -353,25 +313,8 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
     );
   }
 
-  // public componentDidUpdate(previousProps: any, previousState: Ft3asChecklistState) {
-  //   console.log('checklist did update');
-  //   if (previousState != this.state) {
-
-  //     const items = this.filterSourceItems(this.props.checklistDoc?.items ?? [], this.props.visibleCategories, this.props.visibleSeverities);
-  //     this.setState({
-  //       items: items
-  //     });
-  //   }
-  // }
-
   private _getKey(item: ICheckItemAnswered, index?: number): string {
     return item.guid;
-    // console.debug('_getkey ' + item);
-    // return index?.toString() ?? '';
-  }
-
-  private _onItemInvoked(item: any): void {
-    alert(`Item invoked: `);
   }
 
   private _getSelectionDetails(): string {
@@ -386,8 +329,6 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
         return `${selectionCount} items selected`;
     }
   }
-
-
 
   private _onColumnClick = (ev: React.MouseEvent<HTMLElement> | undefined, column: IColumn): void => {
     let _groupingField = this.props.groupingField ? this.props.groupingField.key.toString() : 'category'
@@ -406,7 +347,6 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
 }
 
 function setHeader(columns: IColumn[], column: string){
-  
   const newColumns: IColumn[] = columns.slice();
   const currColumn: IColumn = newColumns.filter(currCol => column === currCol.key)[0];
   newColumns.forEach((newCol: IColumn) => {
@@ -423,7 +363,6 @@ function setHeader(columns: IColumn[], column: string){
 }
 
 function _copyAndSort<T>(items: T[], groupKey:string, columnKey: string, isSortedDescending?: boolean): T[] {
-
   if (groupKey === columnKey && groupKey !== 'status'){
     const key = groupKey as keyof T;
     return items.slice(0).sort((a: T, b: T) => ((a[key] > b[key]) ? 1 : -1));
@@ -466,5 +405,4 @@ function _copyAndSort<T>(items: T[], groupKey:string, columnKey: string, isSorte
       return 0;
     });
   }
-
 }

--- a/src/controls/Ft3asChecklist.tsx
+++ b/src/controls/Ft3asChecklist.tsx
@@ -1,38 +1,51 @@
-import * as React from 'react';
-import { Announced } from '@fluentui/react/lib/Announced';
-import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn, IGroup } from '@fluentui/react/lib/DetailsList';
-import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
-import { mergeStyleSets } from '@fluentui/react/lib/Styling';
-import { ICheckItemAnswered } from '../model/ICheckItem';
-import { ICategory, IChecklistDocument } from '../model/IChecklistDocument';
-import { Label, Separator, Stack, IDropdownOption, IStackStyles } from '@fluentui/react';
-import { ISeverity } from '../model/ISeverity';
-import { IStatus } from '../model/IStatus';
-import Ft3asItemDetail from './Ft3asItemDetail';
+import * as React from "react";
+import { Announced } from "@fluentui/react/lib/Announced";
+import {
+  DetailsList,
+  DetailsListLayoutMode,
+  Selection,
+  SelectionMode,
+  IColumn,
+  IGroup,
+} from "@fluentui/react/lib/DetailsList";
+import { MarqueeSelection } from "@fluentui/react/lib/MarqueeSelection";
+import { mergeStyleSets } from "@fluentui/react/lib/Styling";
+import { ICheckItemAnswered } from "../model/ICheckItem";
+import { ICategory, IChecklistDocument } from "../model/IChecklistDocument";
+import {
+  Label,
+  Separator,
+  Stack,
+  IDropdownOption,
+  IStackStyles,
+} from "@fluentui/react";
+import { ISeverity } from "../model/ISeverity";
+import { IStatus } from "../model/IStatus";
+import Ft3asItemDetail from "./Ft3asItemDetail";
 
 const classNames = mergeStyleSets({
   controlWrapper: {
-    display: 'flex',
-    flexWrap: 'wrap',
+    display: "flex",
+    flexWrap: "wrap",
   },
   exampleToggle: {
-    display: 'inline-block',
-    marginBottom: '10px',
-    marginRight: '30px',
+    display: "inline-block",
+    marginBottom: "10px",
+    marginRight: "30px",
   },
   selectionDetails: {
-    marginBottom: '20px',
+    marginBottom: "20px",
   },
 });
 
 const stackStyles: Partial<IStackStyles> = {
   root: {
-    backgroundColor: 'azure',
-    position: 'sticky',
-    top: '10px',
+    backgroundColor: "azure",
+    position: "sticky",
+    top: "10px",
     zIndex: 1,
-    padding: '10px',
-    border: 'solid 1px lightskyblue'
+    padding: "10px",
+    border: "solid 1px lightskyblue",
   },
 };
 
@@ -56,7 +69,10 @@ interface Ft3asChecklistProps {
   groupingField?: IDropdownOption;
 }
 
-export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asChecklistState> {
+export class Ft3asChecklist extends React.Component<
+  Ft3asChecklistProps,
+  Ft3asChecklistState
+> {
   private _selection: Selection;
 
   constructor(props: Ft3asChecklistProps) {
@@ -64,76 +80,88 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
 
     const columns: IColumn[] = [
       {
-        key: 'subcategory',
-        name: 'Subcategory',
-        fieldName: 'subcategory',
+        key: "subcategory",
+        name: "Subcategory",
+        fieldName: "subcategory",
         minWidth: 60,
         maxWidth: 150,
         isRowHeader: true,
         isResizable: true,
-        sortAscendingAriaLabel: 'Sorted A to Z',
-        sortDescendingAriaLabel: 'Sorted Z to A',
+        sortAscendingAriaLabel: "Sorted A to Z",
+        sortDescendingAriaLabel: "Sorted Z to A",
         onColumnClick: this._onColumnClick,
-        data: 'string',
+        data: "string",
         isPadded: true,
       },
       {
-        key: 'text',
-        name: 'Text',
-        fieldName: 'text',
+        key: "text",
+        name: "Text",
+        fieldName: "text",
         minWidth: 210,
         maxWidth: 350,
         isResizable: true,
         onColumnClick: this._onColumnClick,
-        data: 'string',
+        data: "string",
       },
       {
-        key: 'comments',
-        name: 'Comments',
-        fieldName: 'comments',
+        key: "comments",
+        name: "Comments",
+        fieldName: "comments",
         minWidth: 210,
         maxWidth: 350,
         isResizable: true,
         onColumnClick: this._onColumnClick,
-        data: 'string',
+        data: "string",
       },
       {
-        key: 'status',
-        name: 'Status',
-        fieldName: 'status',
+        key: "status",
+        name: "Status",
+        fieldName: "status",
         minWidth: 70,
         maxWidth: 90,
         isResizable: true,
         isCollapsible: true,
         onRender: (item: ICheckItemAnswered) => item.status?.name,
 
-        onColumnClick: this._onColumnClick
+        onColumnClick: this._onColumnClick,
       },
       {
-        key: 'severity',
-        name: 'Severity',
-        fieldName: 'severity',
+        key: "severity",
+        name: "Severity",
+        fieldName: "severity",
         minWidth: 70,
         maxWidth: 90,
         isResizable: true,
         isCollapsible: true,
-        data: 'string',
+        data: "string",
         onColumnClick: this._onColumnClick,
-      }
+      },
     ];
 
     this._selection = new Selection({
       onSelectionChanged: () => {
-        console.debug('onSelectionChanged');
         this.setState({
           selectionDetails: this._getSelectionDetails(),
-          currentItem: this._selection.getSelection()[0] as ICheckItemAnswered
+          currentItem: this._selection.getSelection()[0] as ICheckItemAnswered,
         });
       },
     });
 
-    const items = this.filterSourceItems(this.props.checklistDoc?.items ?? [], this.props.visibleCategories, this.props.visibleSeverities, this.props.visibleStatuses, this.props.filterText);
-    const result = this.setGroups(items, this.props.visibleCategories, this.props.visibleSeverities, this.props.visibleStatuses, this.props.groupingField?.key.toString(), columns);
+    const items = this.filterSourceItems(
+      this.props.checklistDoc?.items ?? [],
+      this.props.visibleCategories,
+      this.props.visibleSeverities,
+      this.props.visibleStatuses,
+      this.props.filterText
+    );
+    const result = this.setGroups(
+      items,
+      this.props.visibleCategories,
+      this.props.visibleSeverities,
+      this.props.visibleStatuses,
+      this.props.groupingField?.key.toString(),
+      columns
+    );
 
     this.state = {
       allItems: result.items,
@@ -145,56 +173,124 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
     };
   }
 
-  private setGroups(initialItems: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], visibleStatuses?: IStatus[],  groupingField?: string, columns?: IColumn[])
-  {
-    let newColumns = setHeader(columns!, groupingField!)
-    let items = _copyAndSort(initialItems,groupingField!, groupingField!, true);
-    let groups = this.prepareGroups(items, visibleCategories, visibleSeverities, visibleStatuses, groupingField)
+  private setGroups(
+    initialItems: ICheckItemAnswered[],
+    visibleCategories?: ICategory[],
+    visibleSeverities?: ISeverity[],
+    visibleStatuses?: IStatus[],
+    groupingField?: string,
+    columns?: IColumn[]
+  ) {
+    let newColumns = setHeader(columns!, groupingField!);
+    let items = _copyAndSort(
+      initialItems,
+      groupingField!,
+      groupingField!,
+      true
+    );
+    let groups = this.prepareGroups(
+      items,
+      visibleCategories,
+      visibleSeverities,
+      visibleStatuses,
+      groupingField
+    );
 
-    return {groups: groups, items: items, columns: newColumns};
+    return { groups: groups, items: items, columns: newColumns };
   }
 
-  private prepareGroups(items: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], visibleStatuses?: IStatus[],  groupingField?: string){
-    const groups : IGroup[] = [];
+  private prepareGroups(
+    items: ICheckItemAnswered[],
+    visibleCategories?: ICategory[],
+    visibleSeverities?: ISeverity[],
+    visibleStatuses?: IStatus[],
+    groupingField?: string
+  ) {
+    const groups: IGroup[] = [];
 
-    if (groupingField === 'severity')
-    {
-      visibleSeverities?.forEach(item => 
-        {
-          let _count = items.filter(i=> i.severity.toString() === item.name).length;
-          let _startIndex = items.map(function(e) { return e.severity.toString(); }).indexOf(item.name);
-          groups.push({ key: item.name, name: item.name, startIndex: (_startIndex? _startIndex : 0) , count: (_count? _count : 0), level: 0});
+    if (groupingField === "severity") {
+      visibleSeverities?.forEach((item) => {
+        let _count = items.filter(
+          (i) => i.severity.toString() === item.name
+        ).length;
+        let _startIndex = items
+          .map(function (e) {
+            return e.severity.toString();
+          })
+          .indexOf(item.name);
+        groups.push({
+          key: item.name,
+          name: item.name,
+          startIndex: _startIndex ? _startIndex : 0,
+          count: _count ? _count : 0,
+          level: 0,
         });
-    }
-    else if (groupingField === 'status')
-    {
-      visibleStatuses?.forEach(item => 
-        {
-          let _count = items.filter(i=> i.status?.name === item.name).length;
-          let _startIndex = items.map(function(e) { return e.status?.name; }).indexOf(item.name);
-          groups.push({ key: item.name, name: item.name, startIndex: (_startIndex? _startIndex : 0) , count: (_count? _count : 0), level: 0});
+      });
+    } else if (groupingField === "status") {
+      visibleStatuses?.forEach((item) => {
+        let _count = items.filter((i) => i.status?.name === item.name).length;
+        let _startIndex = items
+          .map(function (e) {
+            return e.status?.name;
+          })
+          .indexOf(item.name);
+        groups.push({
+          key: item.name,
+          name: item.name,
+          startIndex: _startIndex ? _startIndex : 0,
+          count: _count ? _count : 0,
+          level: 0,
         });
-    }
-    else
-    {
-      visibleCategories?.forEach(item => 
-        {
-          let _count = items.filter(i=> i.category === item.name).length;
-          let _startIndex = items.map(function(e) { return e.category; }).indexOf(item.name);
-          groups.push({ key: item.name, name: item.name, startIndex: (_startIndex? _startIndex : 0) , count: (_count? _count : 0), level: 0});
+      });
+    } else {
+      visibleCategories?.forEach((item) => {
+        let _count = items.filter((i) => i.category === item.name).length;
+        let _startIndex = items
+          .map(function (e) {
+            return e.category;
+          })
+          .indexOf(item.name);
+        groups.push({
+          key: item.name,
+          name: item.name,
+          startIndex: _startIndex ? _startIndex : 0,
+          count: _count ? _count : 0,
+          level: 0,
         });
+      });
     }
 
     return groups;
   }
 
   public componentWillReceiveProps(props: Ft3asChecklistProps) {
-    const items = this.filterSourceItems(props.checklistDoc?.items ?? [], props.visibleCategories, props.visibleSeverities, props.visibleStatuses, props.filterText);
-    const result = this.setGroups(items, props.visibleCategories, props.visibleSeverities, props.visibleStatuses, props.groupingField?.key.toString(), this.state.columns);
+    const items = this.filterSourceItems(
+      props.checklistDoc?.items ?? [],
+      props.visibleCategories,
+      props.visibleSeverities,
+      props.visibleStatuses,
+      props.filterText
+    );
+    const result = this.setGroups(
+      items,
+      props.visibleCategories,
+      props.visibleSeverities,
+      props.visibleStatuses,
+      props.groupingField?.key.toString(),
+      this.state.columns
+    );
+    result.groups.forEach((newGroup) => {
+      const _existingGroupFromState = this.state.groups.find(
+        (stateGroup) => stateGroup.key === newGroup.key
+      );
+      if (_existingGroupFromState) {
+        newGroup.isCollapsed = _existingGroupFromState.isCollapsed;
+      }
+    });
     this.setState({
       items: result.items,
       groups: result.groups,
-      columns: result.columns
+      columns: result.columns,
     });
   }
 
@@ -204,31 +300,78 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
     }
   }
 
-  private filterSourceItems(items: ICheckItemAnswered[], visibleCategories?: ICategory[], visibleSeverities?: ISeverity[], visibleStatuses?: IStatus[], filterText?: string): ICheckItemAnswered[] {
-    const _filterText= filterText?.toLowerCase();
-    
-    return items.filter(item =>
-      (visibleCategories === undefined || visibleCategories.findIndex(c => c.name === item.category) !== -1)
-      && (visibleSeverities === undefined || visibleSeverities.findIndex(s => s.name.toLowerCase() === item.severity.toString().toLowerCase()) !== -1)
-      && (visibleStatuses === undefined || visibleStatuses.findIndex(s => item.status && s.name.toLowerCase() === item.status.name.toLowerCase()) !== -1)
-      && (_filterText === undefined || _filterText.trim() === '' || item.category.toLowerCase().indexOf(_filterText) !== -1 || item.subcategory.toLowerCase().indexOf(_filterText) !== -1 || item.text.toLowerCase().indexOf(_filterText) !== -1 || item.severity.toString().toLowerCase().indexOf(_filterText) !== -1));
+  private filterSourceItems(
+    items: ICheckItemAnswered[],
+    visibleCategories?: ICategory[],
+    visibleSeverities?: ISeverity[],
+    visibleStatuses?: IStatus[],
+    filterText?: string
+  ): ICheckItemAnswered[] {
+    const _filterText = filterText?.toLowerCase();
+
+    return items.filter(
+      (item) =>
+        (visibleCategories === undefined ||
+          visibleCategories.findIndex((c) => c.name === item.category) !==
+            -1) &&
+        (visibleSeverities === undefined ||
+          visibleSeverities.findIndex(
+            (s) =>
+              s.name.toLowerCase() === item.severity.toString().toLowerCase()
+          ) !== -1) &&
+        (visibleStatuses === undefined ||
+          visibleStatuses.findIndex(
+            (s) =>
+              item.status &&
+              s.name.toLowerCase() === item.status.name.toLowerCase()
+          ) !== -1) &&
+        (_filterText === undefined ||
+          _filterText.trim() === "" ||
+          item.category.toLowerCase().indexOf(_filterText) !== -1 ||
+          item.subcategory.toLowerCase().indexOf(_filterText) !== -1 ||
+          item.text.toLowerCase().indexOf(_filterText) !== -1 ||
+          item.severity.toString().toLowerCase().indexOf(_filterText) !== -1)
+    );
   }
-  
+
   private onItemChanged(item: ICheckItemAnswered) {
-    console.debug(`comment: ${item.comments} status: ${item.status}`)
-    const index = this.props.checklistDoc?.items.findIndex(c => c.guid === item.guid) ?? -1;
+    const index =
+      this.props.checklistDoc?.items.findIndex((c) => c.guid === item.guid) ??
+      -1;
     if (index !== -1) {
       let newItems = this.props.checklistDoc?.items ?? [];
       newItems[index] = item;
-      let items = this.filterSourceItems(newItems, this.props.checklistDoc?.categories, this.props.checklistDoc?.severities);
-      const result = this.setGroups(items, this.props.checklistDoc?.categories, this.props.checklistDoc?.severities, this.props.checklistDoc?.status, this.props.groupingField?.key.toString(), this.state.columns);
+      let items = this.filterSourceItems(
+        newItems,
+        this.props.checklistDoc?.categories,
+        this.props.checklistDoc?.severities
+      );
+      const result = this.setGroups(
+        items,
+        this.props.checklistDoc?.categories,
+        this.props.checklistDoc?.severities,
+        this.props.checklistDoc?.status,
+        this.props.groupingField?.key.toString(),
+        this.state.columns
+      );
       const notAnswered = this.props.checklistDoc?.status[0];
-      const currentProgress = items.filter(i => i.status !== notAnswered).length / items.length;
+      const currentProgress =
+        items.filter((i) => i.status !== notAnswered).length / items.length;
+
+      result.groups.forEach((newGroup) => {
+        const _existingGroupFromState = this.state.groups.find(
+          (stateGroup) => stateGroup.key === newGroup.key
+        );
+        if (_existingGroupFromState) {
+          newGroup.isCollapsed = _existingGroupFromState.isCollapsed;
+        }
+      });
+
       this.setState({
         allItems: { ...result.items },
         items: result.items,
         groups: result.groups,
-        columns: result.columns
+        columns: result.columns,
       });
       this.questionAnswered(currentProgress);
     } else {
@@ -237,8 +380,12 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
   }
 
   private onNext(currentGuid: string) {
-    const currentIndex = this.state.items.findIndex(a => a.guid === currentGuid);
-    console.debug(`Current index for ${currentGuid} -> (${currentIndex}/${this.state.items.length})`)
+    const currentIndex = this.state.items.findIndex(
+      (a) => a.guid === currentGuid
+    );
+    console.debug(
+      `Current index for ${currentGuid} -> (${currentIndex}/${this.state.items.length})`
+    );
     if (currentIndex !== -1 && currentIndex < this.state.items.length - 1) {
       this._selection.setIndexSelected(currentIndex, false, false);
       this._selection.setIndexSelected(currentIndex + 1, true, true);
@@ -246,8 +393,12 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
   }
 
   private onPrevious(currentGuid: string) {
-    const currentIndex = this.state.items.findIndex(a => a.guid === currentGuid);
-    console.debug(`Current index for ${currentGuid} -> (${currentIndex}/${this.state.items.length})`)
+    const currentIndex = this.state.items.findIndex(
+      (a) => a.guid === currentGuid
+    );
+    console.debug(
+      `Current index for ${currentGuid} -> (${currentIndex}/${this.state.items.length})`
+    );
     if (currentIndex !== -1 && currentIndex > 0) {
       this._selection.setIndexSelected(currentIndex, false, false);
       this._selection.setIndexSelected(currentIndex - 1, true, true);
@@ -255,11 +406,20 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
   }
 
   private onDiscardEdition() {
-    this._selection.toggleIndexSelected(this._selection.getSelectedIndices()[0]);
+    this._selection.toggleIndexSelected(
+      this._selection.getSelectedIndices()[0]
+    );
   }
 
   public render() {
-    const { columns, items, selectionDetails, announcedMessage, currentItem, groups } = this.state;
+    const {
+      columns,
+      items,
+      selectionDetails,
+      announcedMessage,
+      currentItem,
+      groups,
+    } = this.state;
 
     return (
       <Stack>
@@ -271,21 +431,30 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
               onItemChanged={this.onItemChanged.bind(this)}
               onNext={this.onNext.bind(this)}
               onPrevious={this.onPrevious.bind(this)}
-              onDiscard={this.onDiscardEdition.bind(this)} />    
+              onDiscard={this.onDiscardEdition.bind(this)}
+            />
           </Stack>
-          ) : <></>}
+        ) : (
+          <></>
+        )}
         <Stack>
           <Separator>Full list</Separator>
           <div>
             <div className={classNames.controlWrapper}>
-              <Announced message={`Number of items after filter applied: ${items.length}.`} />
+              <Announced
+                message={`Number of items after filter applied: ${items.length}.`}
+              />
             </div>
-            <div className={classNames.selectionDetails}>{selectionDetails}</div>
+            <div className={classNames.selectionDetails}>
+              {selectionDetails}
+            </div>
             <Announced message={selectionDetails} />
             <Label>{`Total: ${this.props.checklistDoc?.items.length} Filtered: ${items.length} `}</Label>
-            {announcedMessage ? <Announced message={announcedMessage} /> : undefined}
+            {announcedMessage ? (
+              <Announced message={announcedMessage} />
+            ) : undefined}
 
-            <MarqueeSelection selection={this._selection} >
+            <MarqueeSelection selection={this._selection}>
               <DetailsList
                 items={items}
                 groups={groups}
@@ -306,7 +475,6 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
                 checkButtonAriaLabel="select row"
               />
             </MarqueeSelection>
-
           </div>
         </Stack>
       </Stack>
@@ -322,33 +490,63 @@ export class Ft3asChecklist extends React.Component<Ft3asChecklistProps, Ft3asCh
 
     switch (selectionCount) {
       case 0:
-        return 'No items selected';
+        return "No items selected";
       case 1:
-        return '1 item selected: ' + (this._selection.getSelection()[0] as ICheckItemAnswered).guid;
+        return (
+          "1 item selected: " +
+          (this._selection.getSelection()[0] as ICheckItemAnswered).guid
+        );
       default:
         return `${selectionCount} items selected`;
     }
   }
 
-  private _onColumnClick = (ev: React.MouseEvent<HTMLElement> | undefined, column: IColumn): void => {
-    let _groupingField = this.props.groupingField ? this.props.groupingField.key.toString() : 'category'
+  private _onColumnClick = (
+    ev: React.MouseEvent<HTMLElement> | undefined,
+    column: IColumn
+  ): void => {
+    let _groupingField = this.props.groupingField
+      ? this.props.groupingField.key.toString()
+      : "category";
     const { columns, items } = this.state;
 
-    const newColumns = setHeader(columns, column.key)
-    const newItems = _copyAndSort(items, _groupingField, column.fieldName!, !column.isSortedDescending);
-    let groups = this.prepareGroups(newItems, this.props.checklistDoc?.categories, this.props.checklistDoc?.severities, this.props.checklistDoc?.status, _groupingField)
+    const newColumns = setHeader(columns, column.key);
+    const newItems = _copyAndSort(
+      items,
+      _groupingField,
+      column.fieldName!,
+      !column.isSortedDescending
+    );
+    let newGroups = this.prepareGroups(
+      newItems,
+      this.props.checklistDoc?.categories,
+      this.props.checklistDoc?.severities,
+      this.props.checklistDoc?.status,
+      _groupingField
+    );
+
+    newGroups.forEach((newGroup) => {
+      const _existingGroupFromState = this.state.groups.find(
+        (stateGroup) => stateGroup.key === newGroup.key
+      );
+      if (_existingGroupFromState) {
+        newGroup.isCollapsed = _existingGroupFromState.isCollapsed;
+      }
+    });
 
     this.setState({
       columns: newColumns,
       items: newItems,
-      groups: groups
+      groups: newGroups,
     });
   };
 }
 
-function setHeader(columns: IColumn[], column: string){
+function setHeader(columns: IColumn[], column: string) {
   const newColumns: IColumn[] = columns.slice();
-  const currColumn: IColumn = newColumns.filter(currCol => column === currCol.key)[0];
+  const currColumn: IColumn = newColumns.filter(
+    (currCol) => column === currCol.key
+  )[0];
   newColumns.forEach((newCol: IColumn) => {
     if (newCol === currColumn) {
       currColumn.isSortedDescending = !currColumn.isSortedDescending;
@@ -362,46 +560,69 @@ function setHeader(columns: IColumn[], column: string){
   return newColumns;
 }
 
-function _copyAndSort<T>(items: T[], groupKey:string, columnKey: string, isSortedDescending?: boolean): T[] {
-  if (groupKey === columnKey && groupKey !== 'status'){
+function _copyAndSort<T>(
+  items: T[],
+  groupKey: string,
+  columnKey: string,
+  isSortedDescending?: boolean
+): T[] {
+  if (groupKey === columnKey && groupKey !== "status") {
     const key = groupKey as keyof T;
-    return items.slice(0).sort((a: T, b: T) => ((a[key] > b[key]) ? 1 : -1));
-  }
-  else if (groupKey === columnKey && groupKey === 'status'){
+    return items.slice(0).sort((a: T, b: T) => (a[key] > b[key] ? 1 : -1));
+  } else if (groupKey === columnKey && groupKey === "status") {
     const key = groupKey as keyof T;
-    return items.slice(0).sort((a: T, b: T) => (((a[key] as unknown as IStatus).name > (b[key] as unknown as IStatus).name) ? 1 : -1));
-  }
-  else if (columnKey === 'status'){
+    return items
+      .slice(0)
+      .sort((a: T, b: T) =>
+        (a[key] as unknown as IStatus).name >
+        (b[key] as unknown as IStatus).name
+          ? 1
+          : -1
+      );
+  } else if (columnKey === "status") {
     const group = groupKey as keyof T;
     const key = columnKey as keyof T;
     return items.slice(0).sort((a: T, b: T) => {
       if (a[group] < b[group]) return -1;
       if (a[group] > b[group]) return 1;
-      if ((a[key] as unknown as IStatus).name < (b[key] as unknown as IStatus).name) return isSortedDescending? 1 : -1;
-      if ((a[key] as unknown as IStatus).name > (b[key] as unknown as IStatus).name) return isSortedDescending? -1 : 1;
+      if (
+        (a[key] as unknown as IStatus).name <
+        (b[key] as unknown as IStatus).name
+      )
+        return isSortedDescending ? 1 : -1;
+      if (
+        (a[key] as unknown as IStatus).name >
+        (b[key] as unknown as IStatus).name
+      )
+        return isSortedDescending ? -1 : 1;
       return 0;
     });
-  }
-  else if (groupKey === 'status'){
+  } else if (groupKey === "status") {
     const group = groupKey as keyof T;
     const key = columnKey as keyof T;
     return items.slice(0).sort((a: T, b: T) => {
-      if ((a[group] as unknown as IStatus).name < (b[group] as unknown as IStatus).name) return -1;
-      if ((a[group] as unknown as IStatus).name > (b[group] as unknown as IStatus).name) return 1;
-      if (a[key] < b[key]) return isSortedDescending? 1 : -1;
-      if (a[key] > b[key]) return isSortedDescending? -1 : 1;
+      if (
+        (a[group] as unknown as IStatus).name <
+        (b[group] as unknown as IStatus).name
+      )
+        return -1;
+      if (
+        (a[group] as unknown as IStatus).name >
+        (b[group] as unknown as IStatus).name
+      )
+        return 1;
+      if (a[key] < b[key]) return isSortedDescending ? 1 : -1;
+      if (a[key] > b[key]) return isSortedDescending ? -1 : 1;
       return 0;
     });
-  }
-  else
-  {
+  } else {
     const group = groupKey as keyof T;
     const key = columnKey as keyof T;
     return items.slice(0).sort((a: T, b: T) => {
       if (a[group] < b[group]) return -1;
       if (a[group] > b[group]) return 1;
-      if (a[key] < b[key]) return isSortedDescending? 1 : -1;
-      if (a[key] > b[key]) return isSortedDescending? -1 : 1;
+      if (a[key] < b[key]) return isSortedDescending ? 1 : -1;
+      if (a[key] > b[key]) return isSortedDescending ? -1 : 1;
       return 0;
     });
   }

--- a/src/controls/Ft3asFilters.tsx
+++ b/src/controls/Ft3asFilters.tsx
@@ -1,290 +1,411 @@
-import { IInputProps, ITag, Panel, TagPicker, Dropdown, IDropdownOption, IDropdownStyles } from '@fluentui/react';
-import * as React from 'react';
+import {
+  ITag,
+  Panel,
+  TagPicker,
+  Dropdown,
+  IDropdownOption,
+  IDropdownStyles,
+} from "@fluentui/react";
+import * as React from "react";
 import { ICategory, IChecklistDocument } from "../model/IChecklistDocument";
-import { ISeverity } from '../model/ISeverity';
-import { IStatus } from '../model/IStatus';
-import { TextField } from '@fluentui/react/lib/TextField';
-
+import { ISeverity } from "../model/ISeverity";
+import { IStatus } from "../model/IStatus";
+import { TextField } from "@fluentui/react/lib/TextField";
 
 const getTextFromItem = (item: ITag) => item.name;
 
 const listContainsTagList = (tag: ITag, tagList?: ITag[]) => {
-    if (!tagList || !tagList.length || tagList.length === 0) {
-        return false;
-    }
-    return tagList.some(compareTag => compareTag.key === tag.key);
+  if (!tagList || !tagList.length || tagList.length === 0) {
+    return false;
+  }
+  return tagList.some((compareTag) => compareTag.key === tag.key);
 };
 
 const dropdownStyles: Partial<IDropdownStyles> = {
-    dropdown: { width: 290 },
-  };
-  
-  const options: IDropdownOption[] = [
-    { key: 'category', text: 'Category' },
-    { key: 'status', text: 'Status' },
-    { key: 'severity', text: 'Severity' },
-  ];
-
-const inputProps: IInputProps = {
-    onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),
-    onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called'),
-    onChange: (ev: React.ChangeEvent<HTMLInputElement>) => console.log('onChange called ' + ev.target.value)
+  dropdown: { width: 290 },
 };
 
+const options: IDropdownOption[] = [
+  { key: "category", text: "Category" },
+  { key: "status", text: "Status" },
+  { key: "severity", text: "Severity" },
+];
+
 interface Ft3asFiltersProps {
-    checklistDoc: IChecklistDocument;
-    isOpen: boolean;
-    categoriesChanged?: (selectedCategories: ICategory[]) => void
-    severitiesChanged?: (selectedSeverities: ISeverity[]) => void
-    statusesChanged?: (selectedStatuses: IStatus[]) => void
-    filterTextChanged?: (filterText: string) => void
-    groupChange?: (option: IDropdownOption<any>) => void
-    onClose: () => void;
+  checklistDoc: IChecklistDocument;
+  isOpen: boolean;
+  categoriesChanged?: (selectedCategories: ICategory[]) => void;
+  severitiesChanged?: (selectedSeverities: ISeverity[]) => void;
+  statusesChanged?: (selectedStatuses: IStatus[]) => void;
+  filterTextChanged?: (filterText: string) => void;
+  groupChange?: (option: IDropdownOption<any>) => void;
+  onClose: () => void;
 }
 export default function Ft3asFilters(props: Ft3asFiltersProps) {
+  const { categories, severities, status } = props.checklistDoc;
+  const { isOpen } = props;
 
-    const { categories, severities, status } = props.checklistDoc;
-    const { isOpen } = props;
-    const availableTags = categories.map<ITag>(c => {
-        return { key: c.name, name: c.name }
+  const availableTags = categories.map<ITag>((c) => {
+    return { key: c.name, name: c.name };
+  });
+  const [includedTags, setIncludedTags] = React.useState<ITag[]>(availableTags);
+  const [excludedTags, setExcludedTags] = React.useState<ITag[]>([]);
+
+  const availableSeverities = severities.map<ITag>((s) => {
+    return { key: s.name, name: s.name };
+  });
+  const [includedSeverities, setIncludedSeverities] =
+    React.useState<ITag[]>(availableSeverities);
+  const [excludedSeverities, setExcludedSeverities] = React.useState<ITag[]>(
+    []
+  );
+
+  const availableStatuses = status.map<ITag>((s) => {
+    return { key: s.name, name: s.name };
+  });
+  const [includedStatuses, setIncludedStatuses] =
+    React.useState<ITag[]>(availableStatuses);
+  const [excludedStatuses, setExcludedStatuses] = React.useState<ITag[]>([]);
+
+  const [groupingField, setGroupingField] = React.useState<IDropdownOption>(
+    options[0]
+  );
+
+  const filterSuggestedCategoryTags = (
+    filterText: string,
+    tagList?: ITag[]
+  ): ITag[] => {
+    return filterText
+      ? availableTags.filter(
+          (tag) =>
+            tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 &&
+            !listContainsTagList(tag, tagList)
+        )
+      : [];
+  };
+
+  const filterExcludedCategoryTags = (
+    filterText: string,
+    tagList?: ITag[]
+  ): ITag[] => {
+    return filterText
+      ? excludedTags.filter(
+          (tag) =>
+            tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 &&
+            !listContainsTagList(tag, tagList)
+        )
+      : [];
+  };
+
+  const filterSuggestedSeveritiesTags = (
+    filterText: string,
+    tagList?: ITag[]
+  ): ITag[] => {
+    return filterText
+      ? availableSeverities.filter(
+          (tag) =>
+            tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 &&
+            !listContainsTagList(tag, tagList)
+        )
+      : [];
+  };
+
+  const filterExcludedSeverityTags = (
+    filterText: string,
+    tagList?: ITag[]
+  ): ITag[] => {
+    return filterText
+      ? excludedSeverities.filter(
+          (tag) =>
+            tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 &&
+            !listContainsTagList(tag, tagList)
+        )
+      : [];
+  };
+
+  const filterSuggestedStatusesTags = (
+    filterText: string,
+    tagList?: ITag[]
+  ): ITag[] => {
+    return filterText
+      ? availableStatuses.filter(
+          (tag) =>
+            tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 &&
+            !listContainsTagList(tag, tagList)
+        )
+      : [];
+  };
+
+  const filterExcludedStatusesTags = (
+    filterText: string,
+    tagList?: ITag[]
+  ): ITag[] => {
+    return filterText
+      ? excludedStatuses.filter(
+          (tag) =>
+            tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 &&
+            !listContainsTagList(tag, tagList)
+        )
+      : [];
+  };
+
+  const onIncludedCategoriesPickerChanged = (items?: ITag[] | undefined) => {
+    setIncludedTags([...(items ?? [])]);
+
+    let _excludedTags: ITag[] = [];
+    setExcludedTags([]);
+    availableTags.forEach((tag: ITag) => {
+      if (!listContainsTagList(tag, items)) {
+        _excludedTags.push(tag);
+      }
     });
-    const availableSeverities = severities.map<ITag>(s => {
-        return { key: s.name, name: s.name }
+    setExcludedTags(_excludedTags);
+
+    if (props.categoriesChanged) {
+      props.categoriesChanged(
+        items?.map<ICategory>((item) => {
+          return {
+            name: item.name,
+          };
+        }) ?? []
+      );
+    }
+  };
+
+  const onExcludedCategoriesPickerChanged = (items?: ITag[] | undefined) => {
+    setExcludedTags([...(items ?? [])]);
+
+    let _includedTags: ITag[] = [];
+    setIncludedTags([]);
+    availableTags.forEach((tag: ITag) => {
+      if (!listContainsTagList(tag, items)) {
+        _includedTags.push(tag);
+      }
     });
-    const availableStatuses = status.map<ITag>(s => {
-        return { key: s.name, name: s.name }
+    setIncludedTags(_includedTags);
+
+    if (props.categoriesChanged) {
+      props.categoriesChanged(
+        _includedTags?.map<ICategory>((item) => {
+          return {
+            name: item.name,
+          };
+        }) ?? []
+      );
+    }
+  };
+
+  const onIncludedSeveritiesPickerChanged = (items?: ITag[] | undefined) => {
+    setIncludedSeverities([...(items ?? [])]);
+
+    let _excludedSeverities: ITag[] = [];
+    setExcludedSeverities([]);
+    availableSeverities.forEach((tag: ITag) => {
+      if (!listContainsTagList(tag, items)) {
+        _excludedSeverities.push(tag);
+      }
     });
+    setExcludedSeverities(_excludedSeverities);
 
-    const [excludedTags, setExcludedTags] = React.useState<ITag[]>([]);
-    const [excludedSeverities, setExcludedSeverities] = React.useState<ITag[]>([]);
-    const [excludedStatuses, setExcludedStatuses] = React.useState<ITag[]>([]);
-    const [groupingField, setGroupingField] = React.useState<IDropdownOption>(options[0]);
-    
+    if (props.severitiesChanged) {
+      props.severitiesChanged(
+        items?.map<ISeverity>((item) => {
+          return {
+            name: item.name,
+            description: item.name,
+          };
+        }) ?? []
+      );
+    }
+  };
 
-    const filterSuggestedCategoryTags = (filterText: string, tagList?: ITag[]): ITag[] => {
-        return filterText
-            ? availableTags.filter(
-                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
-            : [];
-    };
+  const onExcludedSeveritiesPickerChanged = (items?: ITag[] | undefined) => {
+    setExcludedSeverities([...(items ?? [])]);
 
-    const filterExcludedCategoryTags = (filterText: string, tagList?: ITag[]): ITag[] => {
-        return filterText
-            ? excludedTags.filter(
-                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
-            : [];
-    };
+    let _includedSeverities: ITag[] = [];
+    setIncludedSeverities([]);
+    availableSeverities.forEach((tag: ITag) => {
+      if (!listContainsTagList(tag, items)) {
+        _includedSeverities.push(tag);
+      }
+    });
+    setIncludedSeverities(_includedSeverities);
 
-    const filterSuggestedSeveritiesTags = (filterText: string, tagList?: ITag[]): ITag[] => {
-        return filterText
-            ? availableSeverities.filter(
-                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
-            : [];
-    };
+    if (props.severitiesChanged) {
+      props.severitiesChanged(
+        _includedSeverities?.map<ISeverity>((item) => {
+          return {
+            name: item.name,
+            description: item.name,
+          };
+        }) ?? []
+      );
+    }
+  };
 
-    const filterExcludedSeverityTags = (filterText: string, tagList?: ITag[]): ITag[] => {
-        return filterText
-            ? excludedSeverities.filter(
-                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
-            : [];
-    };
+  const onIncludedStatusesPickerChanged = (items?: ITag[] | undefined) => {
+    setIncludedStatuses([...(items ?? [])]);
 
-    const filterSuggestedStatusesTags = (filterText: string, tagList?: ITag[]): ITag[] => {
-        return filterText
-            ? availableStatuses.filter(
-                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
-            : [];
-    };
+    let _excludedStatuses: ITag[] = [];
+    setExcludedStatuses([]);
+    availableStatuses.forEach((tag: ITag) => {
+      if (!listContainsTagList(tag, items)) {
+        _excludedStatuses.push(tag);
+      }
+    });
+    setExcludedStatuses(_excludedStatuses);
 
-    const filterExcludedStatusesTags = (filterText: string, tagList?: ITag[]): ITag[] => {
-        return filterText
-            ? excludedStatuses.filter(
-                tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0 && !listContainsTagList(tag, tagList))
-            : [];
-    };
+    if (props.statusesChanged) {
+      props.statusesChanged(
+        items?.map<IStatus>((item) => {
+          return {
+            name: item.name,
+            description: item.name,
+          };
+        }) ?? []
+      );
+    }
+  };
 
-    const onCategoriesPickerChanged = (items?: ITag[] | undefined) => {
-        if (props.categoriesChanged) {
-            props.categoriesChanged(items?.map<ICategory>(item => {
-                return {
-                    name: item.name
-                }
-            }) ?? []);
-        }
+  const onExcludedStatusesPickerChanged = (items?: ITag[] | undefined) => {
+    setExcludedStatuses([...(items ?? [])]);
 
-        let _excludedTags : ITag[] = [];
-        setExcludedTags([]);
-        availableTags.forEach( (tag: ITag) => { if(!listContainsTagList(tag, items)) { _excludedTags.push(tag)} });
-        setExcludedTags(_excludedTags);
+    let _includedStatuses: ITag[] = [];
+    setIncludedStatuses([]);
+    availableStatuses.forEach((tag: ITag) => {
+      if (!listContainsTagList(tag, items)) {
+        _includedStatuses.push(tag);
+      }
+    });
+    setIncludedStatuses(_includedStatuses);
 
-    };
+    if (props.statusesChanged) {
+      props.statusesChanged(
+        _includedStatuses?.map<IStatus>((item) => {
+          return {
+            name: item.name,
+            description: item.name,
+          };
+        }) ?? []
+      );
+    }
+  };
 
-    const onSeveritiesPickerChanged = (items?: ITag[] | undefined) => {
-        if (props.severitiesChanged) {
-            props.severitiesChanged(items?.map<ISeverity>(item => {
-                return {
-                    name: item.name,
-                    description: item.name
-                }
-            }) ?? []);
-        }
+  const _onChangeText = (
+    ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+    text?: string
+  ): void => {
+    if (props.filterTextChanged && text) {
+      props.filterTextChanged(text);
+    } else if (props.filterTextChanged) {
+      props.filterTextChanged("");
+    }
+  };
 
-        let _excludedSeverities : ITag[] = [];
-        setExcludedSeverities([]);
-        availableSeverities.forEach( (tag: ITag) => { if(!listContainsTagList(tag, items)) { _excludedSeverities.push(tag)} });
-        setExcludedSeverities(_excludedSeverities);
-    };
+  const onGroupChange = (
+    event: React.FormEvent<HTMLDivElement>,
+    option?: IDropdownOption<any> | undefined,
+    index?: number | undefined
+  ): void => {
+    if (props.groupChange && option) {
+      setGroupingField(option);
+      props.groupChange(option);
+    }
+  };
 
-    const onStatusesPickerChanged = (items?: ITag[] | undefined) => {
-        if (props.statusesChanged) {
-            props.statusesChanged(items?.map<IStatus>(item => {
-                return {
-                    name: item.name,
-                    description: item.name
-                }
-            }) ?? []);
-        }
+  return (
+    <Panel isOpen={isOpen} isBlocking={false} onDismiss={props.onClose}>
+      <Dropdown
+        label="Group by: "
+        selectedKey={groupingField ? groupingField.key : undefined}
+        options={options}
+        styles={dropdownStyles}
+        onChange={onGroupChange}
+      />
+      <TextField
+        label="Filter by name:"
+        onChange={_onChangeText}
+        readOnly={false}
+      />
+      <label htmlFor="picker1">Included categories</label>
+      <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Included categories"
+        onResolveSuggestions={filterSuggestedCategoryTags}
+        getTextFromItem={getTextFromItem}
+        pickerSuggestionsProps={{
+          suggestionsHeaderText: "Suggested categories",
+          noResultsFoundText: "No categories found",
+        }}
+        selectedItems={includedTags}
+        onChange={onIncludedCategoriesPickerChanged}
+      />
 
-        let _excludedStatuses : ITag[] = [];
-        setExcludedStatuses([]);
-        availableStatuses.forEach( (tag: ITag) => { if(!listContainsTagList(tag, items)) { _excludedStatuses.push(tag)} });
-        setExcludedStatuses(_excludedStatuses);
-    };
-  
-    const _onChangeText = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text?: string): void => {
-        if (props.filterTextChanged && text) {
-            props.filterTextChanged(text);
-        }
-        else if (props.filterTextChanged)
-        {
-            props.filterTextChanged('');
-        }
-    };
+      <label htmlFor="picker3">Excluded categories</label>
+      <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Excluded categories"
+        onResolveSuggestions={filterExcludedCategoryTags}
+        getTextFromItem={getTextFromItem}
+        selectedItems={excludedTags}
+        onChange={onExcludedCategoriesPickerChanged}
+      />
 
-    const onGroupChange = (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption<any> | undefined, index?: number | undefined): void => {        
-        if (props.groupChange && option) {
-            setGroupingField(option);
-            props.groupChange(option);
-        }
-    };
+      <label htmlFor="picker2">Included severities</label>
+      <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Included severities"
+        onItemSelected={(selectedItem?: ITag) => {
+          console.debug("seleted item " + selectedItem?.name);
+          return selectedItem ?? null;
+        }}
+        onResolveSuggestions={filterSuggestedSeveritiesTags}
+        getTextFromItem={getTextFromItem}
+        pickerSuggestionsProps={{
+          suggestionsHeaderText: "Suggested severities",
+          noResultsFoundText: "No severities found",
+        }}
+        selectedItems={includedSeverities}
+        onChange={onIncludedSeveritiesPickerChanged}
+      />
 
-    return (
-        <Panel
-            isOpen={isOpen}
-            isBlocking={false}
-            onDismiss={props.onClose}
-        >
-            <Dropdown
-              label="Group by: "
-              selectedKey={groupingField ? groupingField.key : undefined}
-              options={options}
-              styles={dropdownStyles}
-              onChange={onGroupChange}
-            />
-            <TextField label="Filter by name:" onChange={_onChangeText} readOnly={false} />
-            <label htmlFor='picker1'>Included categories</label>
-            <TagPicker
-                removeButtonAriaLabel="Remove"
-                selectionAriaLabel="Included categories"
-                onResolveSuggestions={filterSuggestedCategoryTags}
-                getTextFromItem={getTextFromItem}
-                pickerSuggestionsProps={{
-                    suggestionsHeaderText: 'Suggested categories',
-                    noResultsFoundText: 'No categories found'
-                }}
-                defaultSelectedItems={availableTags}
-                inputProps={{
-                    ...inputProps,
-                    id: 'picker1',
-                }}
-                onChange={onCategoriesPickerChanged}
+      <label htmlFor="picker4">Excluded severities</label>
+      <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Excluded severities"
+        onResolveSuggestions={filterExcludedSeverityTags}
+        selectedItems={excludedSeverities}
+        getTextFromItem={getTextFromItem}
+        onChange={onExcludedSeveritiesPickerChanged}
+      />
 
-            />
+      <label htmlFor="picker5">Included statuses</label>
+      <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Included statuses"
+        onItemSelected={(selectedItem?: ITag) => {
+          console.debug("selected item " + selectedItem?.name);
+          return selectedItem ?? null;
+        }}
+        onResolveSuggestions={filterSuggestedStatusesTags}
+        getTextFromItem={getTextFromItem}
+        pickerSuggestionsProps={{
+          suggestionsHeaderText: "Suggested statuses",
+          noResultsFoundText: "No statuses found",
+        }}
+        selectedItems={includedStatuses}
+        onChange={onIncludedStatusesPickerChanged}
+      />
 
-            <label htmlFor='picker3'>Excluded categories</label>
-            <TagPicker
-                removeButtonAriaLabel="Remove"
-                selectionAriaLabel="Excluded categories"
-                onResolveSuggestions={filterExcludedCategoryTags}
-                selectedItems={excludedTags}
-                getTextFromItem={getTextFromItem}
-                inputProps={{
-                    ...inputProps,
-                    id: 'picker3',
-                }}
-            />
-
-            <label htmlFor='picker2'>Included severities</label>
-            <TagPicker
-                removeButtonAriaLabel="Remove"
-                selectionAriaLabel="Included severities"
-                
-                onItemSelected={(selectedItem?: ITag) => {
-                    console.debug('seleted item ' + selectedItem?.name);
-                    return selectedItem ?? null;
-                }}
-                onResolveSuggestions={filterSuggestedSeveritiesTags}
-                getTextFromItem={getTextFromItem}
-                pickerSuggestionsProps={{
-                    suggestionsHeaderText: 'Suggested severities',
-                    noResultsFoundText: 'No severities found'
-                }}
-                defaultSelectedItems={availableSeverities}
-                inputProps={{
-                    ...inputProps,
-                    id: 'picker2',
-                }}
-                onChange={onSeveritiesPickerChanged}
-            />
-
-            <label htmlFor='picker4'>Excluded severities</label>
-            <TagPicker
-                removeButtonAriaLabel="Remove"
-                selectionAriaLabel="Excluded severities"
-                onResolveSuggestions={filterExcludedSeverityTags}
-                selectedItems={excludedSeverities}
-                getTextFromItem={getTextFromItem}
-                inputProps={{
-                    ...inputProps,
-                    id: 'picker4',
-                }}
-            />
-
-            <label htmlFor='picker5'>Included statuses</label>
-            <TagPicker
-                removeButtonAriaLabel="Remove"
-                selectionAriaLabel="Included statuses"
-                
-                onItemSelected={(selectedItem?: ITag) => {
-                    console.debug('selected item ' + selectedItem?.name);
-                    return selectedItem ?? null;
-                }}
-                onResolveSuggestions={filterSuggestedStatusesTags}
-                getTextFromItem={getTextFromItem}
-                pickerSuggestionsProps={{
-                    suggestionsHeaderText: 'Suggested statuses',
-                    noResultsFoundText: 'No statuses found'
-                }}
-                defaultSelectedItems={availableStatuses}
-                inputProps={{
-                    ...inputProps,
-                    id: 'picker5',
-                }}
-                onChange={onStatusesPickerChanged}
-            />
-
-            <label htmlFor='picker6'>Excluded statuses</label>
-            <TagPicker
-                removeButtonAriaLabel="Remove"
-                selectionAriaLabel="Excluded statuses"
-                onResolveSuggestions={filterExcludedStatusesTags}
-                selectedItems={excludedStatuses}
-                getTextFromItem={getTextFromItem}
-                inputProps={{
-                    ...inputProps,
-                    id: 'picker6',
-                }}
-            />            
-        </Panel>
-    );
+      <label htmlFor="picker6">Excluded statuses</label>
+      <TagPicker
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Excluded statuses"
+        onResolveSuggestions={filterExcludedStatusesTags}
+        selectedItems={excludedStatuses}
+        getTextFromItem={getTextFromItem}
+        onChange={onExcludedStatusesPickerChanged}
+      />
+    </Panel>
+  );
 }

--- a/src/controls/Ft3asItemDetail.tsx
+++ b/src/controls/Ft3asItemDetail.tsx
@@ -194,7 +194,7 @@ export default function Ft3asItemDetail(props: Ft3asItemDetailProps) {
                             <TextField
                                 label="Comments"
                                 multiline
-                                rows={3}
+                                rows={4}
                                 value={comments}
                                 onChange={onCommentsChanged}
                                 onBlur={onFocusOut} />

--- a/src/controls/Ft3asNavApp.tsx
+++ b/src/controls/Ft3asNavApp.tsx
@@ -41,7 +41,7 @@ export default function Ft3asNavApp() {
                             groups={navLinkGroups}
                         />
                     </Stack.Item>
-                    <Stack.Item>
+                    <Stack.Item grow>
                         <Switch>
                             <Route path="/checklist" component={Ft3asApp} />
                             <Route path="/" component={Ft3asHome} />

--- a/src/controls/Ft3asToolbar.tsx
+++ b/src/controls/Ft3asToolbar.tsx
@@ -36,11 +36,11 @@ export function Ft3asToolbar(props: Ft3asToolbarProps) {
         if (props.isModified === true) {
             setChoice(true)
             setAction('upload');
-        } else
+        } else {
             if (props.onUploadReviewClick) {
                 props.onUploadReviewClick(ev);
             }
-
+        }
     };
 
     const _onSelectTemplateClick = (ev: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined): void => {
@@ -94,18 +94,6 @@ export function Ft3asToolbar(props: Ft3asToolbarProps) {
 
     const _overflowItems: ICommandBarItemProps[] = [];
 
-    const _farItems: ICommandBarItemProps[] = [
-        {
-            key: 'info',
-            text: 'Info',
-            // This needs an ariaLabel since it's icon-only
-            ariaLabel: 'Info',
-            iconOnly: true,
-            iconProps: { iconName: 'Info' },
-            onClick: () => console.log('Info'),
-        },
-    ];
-
     const _proceedClick = (ev: React.MouseEvent<HTMLElement>, action: string | undefined): void => {
         setChoice(false)
         if (action === 'upload' && props.onUploadReviewClick) {
@@ -115,7 +103,6 @@ export function Ft3asToolbar(props: Ft3asToolbarProps) {
             props.onSelectTemplateClick(ev);
         }
     };
-
 
     const SevereExample = (p: INotificationProps) => (
         <MessageBar
@@ -139,7 +126,6 @@ export function Ft3asToolbar(props: Ft3asToolbarProps) {
                 items={_items}
                 overflowItems={_overflowItems}
                 overflowButtonProps={overflowProps}
-                farItems={_farItems}
                 ariaLabel="Inbox actions"
                 primaryGroupAriaLabel="Email actions"
                 farItemsGroupAriaLabel="More actions"
@@ -148,5 +134,3 @@ export function Ft3asToolbar(props: Ft3asToolbarProps) {
         </FocusZone>
     );
 };
-
-


### PR DESCRIPTION
fixes #98 
fixes #101 
fixes #102 

#98:

- Update the UI to allow for the column widths to be resized.
- Also, if the checklist item is not long enough, then not all columns are shown (e.g. "Severity", "Status", etc.). Remove some columns that are redundant, or not so user friendly to show in a long list

#101:

- Allow for keeping collapsed categories after saving a checklist item.

#102:

- Fix "ExcludedCategories", "ExcludedSeverities" and "ExcludedStatuses" that are not currently working.